### PR TITLE
Snap: Sign with platform key

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -37,6 +37,8 @@ LOCAL_PACKAGE_NAME := Snap
 LOCAL_PRIVILEGED_MODULE := true
 LOCAL_CERTIFICATE := platform
 
+LOCAL_CERTIFICATE := platform
+
 LOCAL_AAPT_FLAGS += --rename-manifest-package org.lineageos.snap
 
 #LOCAL_SDK_VERSION := current


### PR DESCRIPTION
Fixes:
  Not granting permission android.permission.PREVENT_POWER_KEY to package org.cyanogenmod.snap
  java.lang.SecurityException: No permission to prevent power key: Neither user 10026 nor current process has android.permission.PREVENT_POWER_KEY